### PR TITLE
Include Layout path in Debug RGB device

### DIFF
--- a/RGB.NET.Devices.Debug/DebugRGBDevice.cs
+++ b/RGB.NET.Devices.Debug/DebugRGBDevice.cs
@@ -16,6 +16,11 @@ namespace RGB.NET.Devices.Debug
         /// <inheritdoc />
         public override DebugRGBDeviceInfo DeviceInfo { get; }
 
+        /// <summary>
+        /// Gets the path used to mock this <see cref="DebugRGBDevice"/>
+        /// </summary>
+        public string LayoutPath { get; }
+
         private Func<Dictionary<LedId, Color>> _syncBackFunc;
         private Action<IEnumerable<Led>> _updateLedsAction;
 
@@ -32,6 +37,7 @@ namespace RGB.NET.Devices.Debug
 
             DeviceLayout layout = DeviceLayout.Load(layoutPath);
             DeviceInfo = new DebugRGBDeviceInfo(layout.Type, layout.Vendor, layout.Model, layout.Lighting, syncBackFunc != null);
+            LayoutPath = layoutPath;
         }
 
         #endregion

--- a/RGB.NET.Devices.Debug/DebugRGBDevice.cs
+++ b/RGB.NET.Devices.Debug/DebugRGBDevice.cs
@@ -17,7 +17,7 @@ namespace RGB.NET.Devices.Debug
         public override DebugRGBDeviceInfo DeviceInfo { get; }
 
         /// <summary>
-        /// Gets the path used to mock this <see cref="DebugRGBDevice"/>
+        /// Gets the path of the layout used to mock this <see cref="DebugRGBDevice"/>
         /// </summary>
         public string LayoutPath { get; }
 
@@ -32,12 +32,12 @@ namespace RGB.NET.Devices.Debug
         /// </summary>
         internal DebugRGBDevice(string layoutPath, Func<Dictionary<LedId, Color>> syncBackFunc = null, Action<IEnumerable<Led>> updateLedsAction = null)
         {
+            this.LayoutPath = layoutPath;
             this._syncBackFunc = syncBackFunc;
             this._updateLedsAction = updateLedsAction;
 
             DeviceLayout layout = DeviceLayout.Load(layoutPath);
             DeviceInfo = new DebugRGBDeviceInfo(layout.Type, layout.Vendor, layout.Model, layout.Lighting, syncBackFunc != null);
-            LayoutPath = layoutPath;
         }
 
         #endregion


### PR DESCRIPTION
This is useful because you may want to know where the layout is located at a later point in time.

In the case of Artemis this is used to determine where the device images are located.