### PR TITLE
Fixed Wooting One Mode key mapping

### DIFF
--- a/RGB.NET.Devices.Wooting/Keyboard/WootingKeyboardLedMappings.cs
+++ b/RGB.NET.Devices.Wooting/Keyboard/WootingKeyboardLedMappings.cs
@@ -32,7 +32,7 @@ namespace RGB.NET.Devices.Wooting.Keyboard
             { LedId.Keyboard_F12, (0,13) },
             { LedId.Keyboard_PrintScreen, (0,14) },
             { LedId.Keyboard_PauseBreak, (0,15) },
-            { LedId.Keyboard_Custom1, (0,20) },
+            { LedId.Keyboard_Custom1, (0,16) },
 
             { LedId.Keyboard_GraveAccentAndTilde, (1,0) },
             { LedId.Keyboard_1, (1,1) },
@@ -128,7 +128,7 @@ namespace RGB.NET.Devices.Wooting.Keyboard
             { LedId.Keyboard_F12, (0,13) },
             { LedId.Keyboard_PrintScreen, (0,14) },
             { LedId.Keyboard_PauseBreak, (0,15) },
-            { LedId.Keyboard_Custom1, (0,20) },
+            { LedId.Keyboard_Custom1, (0,16) },
 
             { LedId.Keyboard_GraveAccentAndTilde, (1,0) },
             { LedId.Keyboard_1, (1,1) },

--- a/RGB.NET.Devices.Wooting/Native/_WootingSDK.cs
+++ b/RGB.NET.Devices.Wooting/Native/_WootingSDK.cs
@@ -46,7 +46,8 @@ namespace RGB.NET.Devices.Wooting.Native
 
             _getDeviceInfoPointer = (GetDeviceInfoPointer)Marshal.GetDelegateForFunctionPointer(GetProcAddress(_dllHandle, "wooting_rgb_device_info"), typeof(GetDeviceInfoPointer));
             _keyboardConnectedPointer = (KeyboardConnectedPointer)Marshal.GetDelegateForFunctionPointer(GetProcAddress(_dllHandle, "wooting_rgb_kbd_connected"), typeof(KeyboardConnectedPointer));
-            _resetPointer = (ResetPointer)Marshal.GetDelegateForFunctionPointer(GetProcAddress(_dllHandle, "wooting_rgb_reset"), typeof(ResetPointer));
+            _resetPointer = (ResetPointer)Marshal.GetDelegateForFunctionPointer(GetProcAddress(_dllHandle, "wooting_rgb_reset_rgb"), typeof(ResetPointer));
+            _closePointer = (ClosePointer)Marshal.GetDelegateForFunctionPointer(GetProcAddress(_dllHandle, "wooting_rgb_close"), typeof(ClosePointer));
             _arrayUpdateKeyboardPointer = (ArrayUpdateKeyboardPointer)Marshal.GetDelegateForFunctionPointer(GetProcAddress(_dllHandle, "wooting_rgb_array_update_keyboard"), typeof(ArrayUpdateKeyboardPointer));
             _arraySetSinglePointer = (ArraySetSinglePointer)Marshal.GetDelegateForFunctionPointer(GetProcAddress(_dllHandle, "wooting_rgb_array_set_single"), typeof(ArraySetSinglePointer));
         }
@@ -81,6 +82,7 @@ namespace RGB.NET.Devices.Wooting.Native
         private static GetDeviceInfoPointer _getDeviceInfoPointer;
         private static KeyboardConnectedPointer _keyboardConnectedPointer;
         private static ResetPointer _resetPointer;
+        private static ClosePointer _closePointer;
         private static ArrayUpdateKeyboardPointer _arrayUpdateKeyboardPointer;
         private static ArraySetSinglePointer _arraySetSinglePointer;
 
@@ -98,6 +100,9 @@ namespace RGB.NET.Devices.Wooting.Native
         private delegate bool ResetPointer();
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate bool ClosePointer();
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ArrayUpdateKeyboardPointer();
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -108,6 +113,7 @@ namespace RGB.NET.Devices.Wooting.Native
         internal static IntPtr GetDeviceInfo() => _getDeviceInfoPointer();
         internal static bool KeyboardConnected() => _keyboardConnectedPointer();
         internal static bool Reset() => _resetPointer();
+        internal static bool Close() => _closePointer();
         internal static bool ArrayUpdateKeyboard() => _arrayUpdateKeyboardPointer();
         internal static bool ArraySetSingle(byte row, byte column, byte red, byte green, byte blue) => _arraySetSinglePointer(row, column, red, green, blue);
 

--- a/RGB.NET.Devices.Wooting/WootingDeviceProvider.cs
+++ b/RGB.NET.Devices.Wooting/WootingDeviceProvider.cs
@@ -146,7 +146,7 @@ namespace RGB.NET.Devices.Wooting
             try { UpdateTrigger?.Dispose(); }
             catch { /* at least we tried */ }
 
-            try { _WootingSDK.Reset(); }
+            try { _WootingSDK.Close(); }
             catch { /* Unlucky.. */ }
 
             try { _WootingSDK.UnloadWootingSDK(); }


### PR DESCRIPTION
Wooting's SDK has two mode keys, since the Mode on the wooting one corresponds to the Scroll Lock key on the wooting two. This pull request only changes the key mapping for the Wooting One.