### PR TITLE
Logitech - Fixed LED mappings to ISO/ANSI compatiblity

### DIFF
--- a/RGB.NET.Devices.Logitech/PerKey/BitmapMapping.cs
+++ b/RGB.NET.Devices.Logitech/PerKey/BitmapMapping.cs
@@ -73,7 +73,7 @@ namespace RGB.NET.Devices.Logitech
             { LedId.Keyboard_P, 208 },
             { LedId.Keyboard_BracketLeft, 212 },
             { LedId.Keyboard_BracketRight, 216 },
-            // { LedId.Keyboard_?, 220 },
+            { LedId.Keyboard_Backslash, 220 },
             { LedId.Keyboard_Delete, 224 },
             { LedId.Keyboard_End, 228 },
             { LedId.Keyboard_PageDown, 232 },
@@ -105,7 +105,7 @@ namespace RGB.NET.Devices.Logitech
             // { LedId.Keyboard_?, 332 },
 
             { LedId.Keyboard_LeftShift, 336 },
-            { LedId.Keyboard_Backslash, 340 },
+            { LedId.Keyboard_NonUsBackslash, 340 },
             { LedId.Keyboard_Z, 344 },
             { LedId.Keyboard_X, 348 },
             { LedId.Keyboard_C, 352 },

--- a/RGB.NET.Devices.Logitech/PerKey/PerKeyIdMapping.cs
+++ b/RGB.NET.Devices.Logitech/PerKey/PerKeyIdMapping.cs
@@ -82,6 +82,7 @@ namespace RGB.NET.Devices.Logitech
             { LedId.Keyboard_Home, LogitechLedId.HOME },
             { LedId.Keyboard_PageUp, LogitechLedId.PAGE_UP },
             { LedId.Keyboard_BracketRight, LogitechLedId.CLOSE_BRACKET },
+            { LedId.Keyboard_NonUsBackslash, LogitechLedId.BACKSLASH },
             { LedId.Keyboard_Backslash, LogitechLedId.BACKSLASH },
             { LedId.Keyboard_NonUsTilde, LogitechLedId.NonUsTilde },
             { LedId.Keyboard_Enter, LogitechLedId.ENTER },


### PR DESCRIPTION
This will break existing ISO layouts because `LedId.Backslash` is now `LedId.NonUsBackslash` for those keyboards.