### PR TITLE
Fix color spreading by overlapped rects 

### DIFF
--- a/RGB.NET.Core/Rendering/Textures/PixelTexture.cs
+++ b/RGB.NET.Core/Rendering/Textures/PixelTexture.cs
@@ -48,6 +48,12 @@ namespace RGB.NET.Core
 
                 if ((width == 0) || (height == 0)) return Color.Transparent;
                 if ((width == 1) && (height == 1)) return GetColor(GetPixelData(x, y));
+                if ((width > 1) && (height > 1))
+                {
+                    //Avoid overlaping of the adjacent and spreading of pixels from one led to another
+                    width--;
+                    height--;
+                }
 
                 int bufferSize = width * height * _dataPerPixel;
                 if (bufferSize <= STACK_ALLOC_LIMIT)


### PR DESCRIPTION
This workaround fixes a problem where a color of a led could spread into contiguous leds if the separation is to small. The bug also causes the Edge leds to be darker or take some bits from the background color.

The workarround works very well but i don't think this is the best solution. I do this pull request just to make the problem visible and give some information about this.

Before workarround
![image](https://user-images.githubusercontent.com/972765/112405483-20c94380-8cf1-11eb-99ba-160e5bb36be7.png)


After workarround
https://media.discordapp.net/attachments/790518442730061824/824452700666069012/unknown.png

