### PR TITLE
G733 Headset fix

### DIFF
--- a/RGB.NET.Devices.Asus/AsusDeviceProvider.cs
+++ b/RGB.NET.Devices.Asus/AsusDeviceProvider.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 using AuraServiceLib;
 using RGB.NET.Core;
 
@@ -45,9 +47,22 @@ namespace RGB.NET.Devices.Asus
 
         protected override void InitializeSDK()
         {
+            PerformHealthCheck();
+
             // ReSharper disable once SuspiciousTypeConversion.Global
             _sdk = (IAuraSdk2)new AuraSdk();
             _sdk.SwitchMode();
+        }
+
+        public void PerformHealthCheck()
+        {
+            var lightingServiceRunning = Process.GetProcessesByName("LightingService").Length != 0;
+
+            while (!lightingServiceRunning)
+            {
+                Thread.Sleep(1000);
+                lightingServiceRunning = Process.GetProcessesByName("LightingService").Length != 0;
+            }
         }
 
         protected override IEnumerable<IRGBDevice> LoadDevices()

--- a/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
+++ b/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
@@ -80,7 +80,6 @@ namespace RGB.NET.Devices.Logitech
             { 0x0A5B, RGBDeviceType.Headset, "G933", LedMappings.ZoneHeadset, (LogitechDeviceType.Headset, 2) },
             { 0x0A87, RGBDeviceType.Headset, "G935", LedMappings.ZoneHeadset, (LogitechDeviceType.Headset, 2) },
             { 0x0A78, RGBDeviceType.Speaker, "G560", LedMappings.ZoneHeadset, (LogitechDeviceType.Speaker, 4) },
-            { 0xAB5, RGBDeviceType.Speaker, "G733", LedMappings.ZoneSpeaker, (LogitechDeviceType.Speaker, 2) },
         };
 
         public static HIDLoader<int, int> PerDeviceDeviceDefinitions { get; } = new(VENDOR_ID)
@@ -97,6 +96,7 @@ namespace RGB.NET.Devices.Logitech
             { 0xC248, RGBDeviceType.Keyboard, "G105", LedMappings.Device, 0 },
             { 0xC222, RGBDeviceType.Keyboard, "G15", LedMappings.Device, 0 },
             { 0xC225, RGBDeviceType.Keyboard, "G11", LedMappings.Device, 0 },
+            { 0xAB5, RGBDeviceType.Headset, "G733", LedMappings.Device, 0 },
         };
 
         #endregion


### PR DESCRIPTION
This is a fix for the G733 Headset. Normally it should be a PerZoneDeviceDefinitions because it has two zones, but this is not working like excepted. I recommend changing the device in PerDeviceDeviceDefinitions because on color is better than no color.

![lghub_dGZz2GZlu7](https://user-images.githubusercontent.com/1434005/119237013-e63a2680-bb3a-11eb-8a49-c0535c10e1b5.png)
