### PR TITLE
Corsair - Fix LT100 support and possible other newer devices

### DIFF
--- a/RGB.NET.Devices.Corsair/CorsairDeviceProvider.cs
+++ b/RGB.NET.Devices.Corsair/CorsairDeviceProvider.cs
@@ -165,6 +165,10 @@ namespace RGB.NET.Devices.Corsair
 
                                     ledOffset += channelDeviceInfo.deviceLedCount;
                                     channelDeviceInfoPtr = new IntPtr(channelDeviceInfoPtr.ToInt64() + channelDeviceInfoStructSize);
+
+                                    // Never go past the amount of LEDs reported by device info
+                                    if (ledOffset >= nativeDeviceInfo.ledsCount)
+                                        break;
                                 }
 
                                 int channelInfoStructSize = Marshal.SizeOf(typeof(_CorsairChannelInfo));

--- a/RGB.NET.Devices.Corsair/Custom/CorsairCustomRGBDeviceInfo.cs
+++ b/RGB.NET.Devices.Corsair/Custom/CorsairCustomRGBDeviceInfo.cs
@@ -80,8 +80,9 @@ namespace RGB.NET.Devices.Corsair
         {
             switch (channelDeviceInfo.type)
             {
+                // Better than nothing
                 case CorsairChannelDeviceType.Invalid:
-                    return "Invalid";
+                    return model;
 
                 case CorsairChannelDeviceType.FanHD:
                     return "HD Fan";


### PR DESCRIPTION
Some findings on the LT100

- Device is reported as `CDT_LightingNodePro`
- This causes RGB.NET to use ChannelsInfo which reports 1 channel
- ChannelDeviceType is `Invalid`
- The channel always reports 4 devices even if only 2 LT100s are connected
- This causes later channels to return invalid LED IDs

The PR contains no LT100-specific logic but simply safeguards against some of the odd properties of this device. 
