### PR TITLE
Fix race condition in TimerUpdateTrigger stop

### DIFF
--- a/RGB.NET.Core/Update/TimerUpdateTrigger.cs
+++ b/RGB.NET.Core/Update/TimerUpdateTrigger.cs
@@ -92,10 +92,20 @@ namespace RGB.NET.Core
                 if (UpdateTask != null)
                 {
                     UpdateTokenSource?.Cancel();
-                    // ReSharper disable once MethodSupportsCancellation
-                    UpdateTask.Wait();
-                    UpdateTask.Dispose();
-                    UpdateTask = null;
+                    try
+                    {
+                        // ReSharper disable once MethodSupportsCancellation
+                        UpdateTask.Wait();
+                    }
+                    catch (AggregateException)
+                    {
+                        // ignored
+                    }
+                    finally
+                    {
+                        UpdateTask.Dispose();
+                        UpdateTask = null;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Calling `Stop()` waits for the task to finish but if it's already cancelled when it starts waiting it throws a TaskCancelledException
This is a race condition and depending on how long the task takes to cancel it either occurs or it doesn't.
