### PR TITLE
Add missing Speaker device type mapping

### DIFF
--- a/RGB.NET.Devices.OpenRGB/Helper.cs
+++ b/RGB.NET.Devices.OpenRGB/Helper.cs
@@ -38,6 +38,7 @@ internal static class Helper
             DeviceType.Mouse => RGBDeviceType.Mouse,
             DeviceType.Mousemat => RGBDeviceType.Mousepad,
             DeviceType.Headset => RGBDeviceType.Headset,
+            DeviceType.Speaker => RGBDeviceType.Speaker,
             DeviceType.HeadsetStand => RGBDeviceType.HeadsetStand,
             _ => RGBDeviceType.Unknown
         };

--- a/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
+++ b/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
@@ -35,9 +35,9 @@ public class OpenRGBDeviceProvider : AbstractRGBDeviceProvider
     public bool ForceAddAllDevices { get; set; } = false;
 
     /// <summary>
-    /// Defines which device types will be separated by zones. Defaults to <see cref="RGBDeviceType.LedStripe" /> | <see cref="RGBDeviceType.Mainboard" />.
+    /// Defines which device types will be separated by zones. Defaults to <see cref="RGBDeviceType.LedStripe" /> | <see cref="RGBDeviceType.Mainboard" | <see cref="RGBDeviceType.Speaker" />.
     /// </summary>
-    public RGBDeviceType PerZoneDeviceFlag { get; } = RGBDeviceType.LedStripe | RGBDeviceType.Mainboard;
+    public RGBDeviceType PerZoneDeviceFlag { get; } = RGBDeviceType.LedStripe | RGBDeviceType.Mainboard | RGBDeviceType.Speaker;
 
     #endregion
 


### PR DESCRIPTION
This PR do two things:

 * Add missing Speaker Device Type mapping (Speaker type exists in both OpenRGB and RGB.NET but the mapping is missing).
 * Allow speaker device types to be used in a per zone basis to allow individual speakers (channels) by freely positioned in Artemis surface editor.