### PR TITLE
Added DevicesChanged event

### DIFF
--- a/RGB.NET.Core/Devices/AbstractRGBDeviceProvider.cs
+++ b/RGB.NET.Core/Devices/AbstractRGBDeviceProvider.cs
@@ -40,7 +40,10 @@ public abstract class AbstractRGBDeviceProvider : IRGBDeviceProvider
     public event EventHandler<ExceptionEventArgs>? Exception;
 
     /// <inheritdoc />
-    public event EventHandler<EventArgs>? DevicesChanged; 
+    public event EventHandler<RGBDeviceAddedEventArgs>? DeviceAdded; 
+
+    /// <inheritdoc />
+    public event EventHandler<RGBDeviceRemovedEventArgs>? DeviceRemoved; 
 
     #endregion
 

--- a/RGB.NET.Core/Devices/AbstractRGBDeviceProvider.cs
+++ b/RGB.NET.Core/Devices/AbstractRGBDeviceProvider.cs
@@ -39,6 +39,9 @@ public abstract class AbstractRGBDeviceProvider : IRGBDeviceProvider
     /// <inheritdoc />
     public event EventHandler<ExceptionEventArgs>? Exception;
 
+    /// <inheritdoc />
+    public event EventHandler<EventArgs>? DevicesChanged; 
+
     #endregion
 
     #region Constructors

--- a/RGB.NET.Core/Devices/IRGBDeviceProvider.cs
+++ b/RGB.NET.Core/Devices/IRGBDeviceProvider.cs
@@ -42,9 +42,14 @@ public interface IRGBDeviceProvider : IDisposable
     event EventHandler<ExceptionEventArgs>? Exception;
 
     /// <summary>
-    /// Occurs when device list changes.
+    /// Occurs when device is added.
     /// </summary>
-    event EventHandler<EventArgs>? DevicesChanged; 
+    event EventHandler<RGBDeviceAddedEventArgs>? DeviceAdded; 
+
+    /// <summary>
+    /// Occurs when device is removed.
+    /// </summary>
+    event EventHandler<RGBDeviceRemovedEventArgs>? DeviceRemoved; 
 
     #endregion
 

--- a/RGB.NET.Core/Devices/IRGBDeviceProvider.cs
+++ b/RGB.NET.Core/Devices/IRGBDeviceProvider.cs
@@ -41,6 +41,11 @@ public interface IRGBDeviceProvider : IDisposable
     /// </summary>
     event EventHandler<ExceptionEventArgs>? Exception;
 
+    /// <summary>
+    /// Occurs when device list changes.
+    /// </summary>
+    event EventHandler<EventArgs>? DevicesChanged; 
+
     #endregion
 
     #region Methods

--- a/RGB.NET.Core/Events/RGBDeviceAddedEventArgs.cs
+++ b/RGB.NET.Core/Events/RGBDeviceAddedEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace RGB.NET.Core;
+
+/// <inheritdoc />
+/// <summary>
+/// Contains the detected device from <see cref="IRGBDeviceProvider" />
+/// </summary>
+public class RGBDeviceAddedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Newly detected device.
+    /// </summary>
+    public IRGBDevice Device { get; }
+
+    /// <inheritdoc />
+    public RGBDeviceAddedEventArgs(IRGBDevice device)
+    {
+        Device = device;
+    }
+}

--- a/RGB.NET.Core/Events/RGBDeviceRemovedEventArgs.cs
+++ b/RGB.NET.Core/Events/RGBDeviceRemovedEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace RGB.NET.Core;
+
+/// <inheritdoc />
+/// <summary>
+/// Contains the removed device from <see cref="IRGBDeviceProvider" />
+/// </summary>
+public class RGBDeviceRemovedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Removed device.
+    /// </summary>
+    public IRGBDevice Device { get; }
+
+    /// <inheritdoc />
+    public RGBDeviceRemovedEventArgs(IRGBDevice device)
+    {
+        Device = device;
+    }
+}


### PR DESCRIPTION
Added DevicesChanged event for implementors to use. Openrgb.net implementation got device change support, my Yeelight implementation also needs this.

Mainly intended for usage with Artemis. One event for any change seems okay to me, but I can add other added/removed events if you want.