### PR TITLE
Add missing Logitech G915 TKL wireless PID

### DIFF
--- a/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
+++ b/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
@@ -73,6 +73,7 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
     {
         { 0x407C, RGBDeviceType.Keyboard, "G915", LedMappings.PerKey, 0 },
         { 0x408E, RGBDeviceType.Keyboard, "G915 TKL", LedMappings.PerKey, 0 },
+        { 0xC232, RGBDeviceType.Keyboard, "G915 TKL", LedMappings.PerKey, 0 },
     };
 
     /// <summary>


### PR DESCRIPTION
Sorry. In last pull-request i forgot this PID of the device it self. Seems also to be a new one.