### PR TITLE
Make all openrgb device led ids start from 1

### DIFF
--- a/RGB.NET.Devices.OpenRGB/PerZone/OpenRGBZoneDevice.cs
+++ b/RGB.NET.Devices.OpenRGB/PerZone/OpenRGBZoneDevice.cs
@@ -40,7 +40,7 @@ public class OpenRGBZoneDevice : AbstractOpenRGBDevice<OpenRGBDeviceInfo>
     {
         Size ledSize = new(19);
         const int LED_SPACING = 20;
-        LedId initialId = Helper.GetInitialLedIdForDeviceType(DeviceInfo.DeviceType) + _initialLed;
+        LedId initialId = Helper.GetInitialLedIdForDeviceType(DeviceInfo.DeviceType);
 
         if (_zone.Type == ZoneType.Matrix)
         {


### PR DESCRIPTION
Starts rgb.net led id's from 1 so that same layout can be used for multiple of same devices, like fans