### PR TITLE
Core - Optimize ToList calls to preallocate when size is known

### DIFF
--- a/RGB.NET.Core/Devices/AbstractRGBDevice.cs
+++ b/RGB.NET.Core/Devices/AbstractRGBDevice.cs
@@ -100,7 +100,7 @@ public abstract class AbstractRGBDevice<TDeviceInfo> : Placeable, IRGBDevice<TDe
         DeviceUpdate();
 
         // Send LEDs to SDK
-        List<Led> ledsToUpdate = GetLedsToUpdate(flushLeds).ToList();
+        List<Led> ledsToUpdate = GetLedsToUpdate(flushLeds).ToList(LedMapping.Count);
 
         foreach (Led led in ledsToUpdate)
             led.Update();

--- a/RGB.NET.Core/Extensions/EnumerableExtensions.cs
+++ b/RGB.NET.Core/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace RGB.NET.Core;
+
+public static class EnumerableExtensions
+{
+    public static List<T> ToList<T>(this IEnumerable<T> source, int capacity) 
+    {
+        List<T> res = new List<T>(capacity);
+        res.AddRange(source);
+        return res;
+    }
+}

--- a/RGB.NET.Devices.Wooting/Generic/WootingUpdateQueue.cs
+++ b/RGB.NET.Devices.Wooting/Generic/WootingUpdateQueue.cs
@@ -20,8 +20,8 @@ public class WootingUpdateQueue : UpdateQueue
     /// Initializes a new instance of the <see cref="WootingUpdateQueue"/> class.
     /// </summary>
     /// <param name="updateTrigger">The update trigger used by this queue.</param>
-    public WootingUpdateQueue(IDeviceUpdateTrigger updateTrigger, byte deviceId)
-        : base(updateTrigger)
+    public WootingUpdateQueue(IDeviceUpdateTrigger updateTrigger, byte deviceId, int initialCapacity)
+        : base(updateTrigger, initialCapacity)
     {
         this._deviceid = deviceId;
     }

--- a/RGB.NET.Devices.Wooting/WootingDeviceProvider.cs
+++ b/RGB.NET.Devices.Wooting/WootingDeviceProvider.cs
@@ -83,10 +83,10 @@ public class WootingDeviceProvider : AbstractRGBDeviceProvider
             {
                 for (byte i = 0; i < _WootingSDK.GetDeviceCount(); i++)
                 {
-                    WootingUpdateQueue updateQueue = new(GetUpdateTrigger(), i);
                     _WootingSDK.SelectDevice(i);
                     _WootingDeviceInfo nativeDeviceInfo = (_WootingDeviceInfo)Marshal.PtrToStructure(_WootingSDK.GetDeviceInfo(), typeof(_WootingDeviceInfo))!;
 
+                    WootingUpdateQueue updateQueue = new(GetUpdateTrigger(), i, nativeDeviceInfo.MaxColumns * nativeDeviceInfo.MaxRows);
                     yield return new WootingKeyboardRGBDevice(new WootingKeyboardRGBDeviceInfo(nativeDeviceInfo, i), updateQueue);
                 }
             }


### PR DESCRIPTION
I was profiling the memory with Rider and noticed the ToList calls in the loop waste quite a lot of memory resizing the list (allocating and copying elements to a new array)

Here are my findings:

# Allocations & GC. These graphs are roughly over the same period of time
## Before
![rider64_91CeliI5cr](https://user-images.githubusercontent.com/29486064/231554267-9d51adfe-7bc8-4ca2-a022-4331b22b29b1.png)
## After
![rider64_h0ecmb342o](https://user-images.githubusercontent.com/29486064/231554287-33d18af9-1fe0-4f57-8161-38346113679a.png)

# Allocated objects per type
## Before
![rider64_qDGGwYOCf5](https://user-images.githubusercontent.com/29486064/231554551-f38f8d96-46d0-4a67-a355-935be0941ff4.png)

## After
![rider64_EO5BJKzSHz](https://user-images.githubusercontent.com/29486064/231554570-c84c5509-c5f5-49e8-a9e3-ac13a083f630.png)
