### PR TITLE
Added Device Connection Events to Corsair

### DIFF
--- a/RGB.NET.Devices.Corsair/Enum/CorsairEventId.cs
+++ b/RGB.NET.Devices.Corsair/Enum/CorsairEventId.cs
@@ -1,0 +1,8 @@
+﻿namespace RGB.NET.Devices.Corsair;
+
+public enum CorsairEventId
+{
+    CEI_Invalid = 0,
+    CEI_DeviceConnectionStatusChangedEvent = 1,
+    CEI_KeyEvent = 1,
+}

--- a/RGB.NET.Devices.Corsair/Enum/CorsairEventId.cs
+++ b/RGB.NET.Devices.Corsair/Enum/CorsairEventId.cs
@@ -2,7 +2,7 @@
 
 public enum CorsairEventId
 {
-    CEI_Invalid = 0,
-    CEI_DeviceConnectionStatusChangedEvent = 1,
-    CEI_KeyEvent = 1,
+    Invalid = 0,
+    DeviceConnectionStatusChangedEvent = 1,
+    KeyEvent = 2,
 }

--- a/RGB.NET.Devices.Corsair/Events/CorsairDeviceConnectionStatusChangedEvent.cs
+++ b/RGB.NET.Devices.Corsair/Events/CorsairDeviceConnectionStatusChangedEvent.cs
@@ -1,0 +1,28 @@
+﻿#pragma warning disable 169 // Field 'x' is never used
+#pragma warning disable 414 // Field 'x' is assigned but its value never used
+#pragma warning disable 649 // Field 'x' is never assigned
+#pragma warning disable IDE1006 // Naming Styles
+// ReSharper disable NotAccessedField.Global
+
+using System.Runtime.InteropServices;
+using RGB.NET.Devices.Corsair.Native;
+
+namespace RGB.NET.Devices.Corsair.Events;
+ 
+/// <summary>
+/// iCUE-SDK: contains information about device that was connected or disconnected
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal sealed class CorsairDeviceConnectionStatusChangedEvent
+{
+    /// <summary>
+    /// iCUE-SDK: null terminated Unicode string that contains unique device identifier
+    /// </summary>
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = _CUESDK.CORSAIR_STRING_SIZE_M)]
+    internal string? deviceId;
+
+    /// <summary>
+    /// iCUE-SDK: true if connected, false if disconnected
+    /// </summary>
+    internal byte isConnected;
+} 

--- a/RGB.NET.Devices.Corsair/Events/CorsairKeyEvent.cs
+++ b/RGB.NET.Devices.Corsair/Events/CorsairKeyEvent.cs
@@ -1,0 +1,33 @@
+﻿#pragma warning disable 169 // Field 'x' is never used
+#pragma warning disable 414 // Field 'x' is assigned but its value never used
+#pragma warning disable 649 // Field 'x' is never assigned
+#pragma warning disable IDE1006 // Naming Styles
+// ReSharper disable NotAccessedField.Global
+
+using System.Runtime.InteropServices;
+using RGB.NET.Devices.Corsair.Native;
+
+namespace RGB.NET.Devices.Corsair.Events;
+
+/// <summary>
+/// iCUE-SDK: contains information about device that was connected or disconnected
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal sealed class CorsairKeyEvent
+{
+    /// <summary>
+    /// iCUE-SDK: null terminated Unicode string that contains unique device identifier
+    /// </summary>
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = _CUESDK.CORSAIR_STRING_SIZE_M)]
+    internal string? deviceId;
+    
+    /// <summary>
+    /// iCUE-SDK: G, M or S key that was pressed/released
+    /// </summary>
+    internal uint keyId;
+    
+    /// <summary>
+    /// iCUE-SDK: true if pressed, false if released
+    /// </summary>
+    internal bool isPressed;
+}

--- a/RGB.NET.Devices.Corsair/Native/_CUESDK.cs
+++ b/RGB.NET.Devices.Corsair/Native/_CUESDK.cs
@@ -87,7 +87,7 @@ internal static unsafe class _CUESDK
 
     private static void CorsairEventCallback(nint context, _CorsairEvent eventData)
     {
-        if (eventData.id != CorsairEventId.CEI_DeviceConnectionStatusChangedEvent)
+        if (eventData.id != CorsairEventId.DeviceConnectionStatusChangedEvent)
         {
             return;
         }

--- a/RGB.NET.Devices.Corsair/Native/_CUESDK.cs
+++ b/RGB.NET.Devices.Corsair/Native/_CUESDK.cs
@@ -68,7 +68,11 @@ internal static unsafe class _CUESDK
     private static void CorsairSessionStateChangedCallback(nint context, _CorsairSessionStateChanged eventData)
     {
         SessionState = eventData.state;
-        SessionStateChanged?.Invoke(null, eventData.state);
+        try
+        {
+            SessionStateChanged?.Invoke(null, eventData.state);
+        }
+        catch { /* dont let exception go to sdk */ }
 
         switch (eventData.state)
         {
@@ -96,7 +100,11 @@ internal static unsafe class _CUESDK
             return;
         }
 
-        DeviceConnectionEvent?.Invoke(null, connectionStatusChangedEvent);
+        try
+        {
+            DeviceConnectionEvent?.Invoke(null, connectionStatusChangedEvent);
+        }
+        catch { /* dont let exception go to sdk */ }
     }
 
     #endregion

--- a/RGB.NET.Devices.Corsair/Native/_CUESDK.cs
+++ b/RGB.NET.Devices.Corsair/Native/_CUESDK.cs
@@ -92,19 +92,18 @@ internal static unsafe class _CUESDK
             return;
         }
 
-        CorsairDeviceConnectionStatusChangedEvent? connectionStatusChangedEvent =
-            Marshal.PtrToStructure<CorsairDeviceConnectionStatusChangedEvent>(eventData.corsairEventUnion.eventPointer);
-
-        if (connectionStatusChangedEvent == null)
-        {
-            return;
-        }
-
         try
         {
+            if (eventData.eventPointer == 0)
+            {
+                return;
+            }
+
+            CorsairDeviceConnectionStatusChangedEvent connectionStatusChangedEvent =
+                Marshal.PtrToStructure<CorsairDeviceConnectionStatusChangedEvent>(eventData.eventPointer)!;
+
             DeviceConnectionEvent?.Invoke(null, connectionStatusChangedEvent);
-        }
-        catch { /* dont let exception go to sdk */ }
+        }catch { /* dont let exception go to sdk */ }
     }
 
     #endregion
@@ -245,10 +244,7 @@ internal static unsafe class _CUESDK
     internal static CorsairError CorsairDisconnect()
     {
         if (!IsConnected) throw new RGBDeviceException("The Corsair-SDK is not connected.");
-        CorsairError corsairDisconnect = _corsairDisconnect();
-        // docs say this event is called with disconnect but doesnt :/
-        CorsairSessionStateChangedCallback(0, new _CorsairSessionStateChanged{state = CorsairSessionState.Closed});
-        return corsairDisconnect;
+        return _corsairDisconnect();
     }
 
     internal static CorsairError CorsairGetDevices(_CorsairDeviceFilter filter, out _CorsairDeviceInfo[] devices)

--- a/RGB.NET.Devices.Corsair/Native/_CorsairEvent.cs
+++ b/RGB.NET.Devices.Corsair/Native/_CorsairEvent.cs
@@ -1,0 +1,43 @@
+﻿#pragma warning disable 169 // Field 'x' is never used
+#pragma warning disable 414 // Field 'x' is assigned but its value never used
+#pragma warning disable 649 // Field 'x' is never assigned
+#pragma warning disable IDE1006 // Naming Styles
+// ReSharper disable NotAccessedField.Global
+
+using System.Runtime.InteropServices;
+using RGB.NET.Devices.Corsair.Events;
+
+namespace RGB.NET.Devices.Corsair.Native;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// iCUE-SDK: contains information about event id and event data
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal sealed class _CorsairEvent
+{
+    /// <summary>
+    /// iCUE-SDK: event identifier
+    /// </summary>
+    internal CorsairEventId id;
+
+    /// <summary>
+    /// iCUE-SDK: Anonymous union with fields:
+    /// const CorsairDeviceConnectionStatusChangedEvent *deviceConnectionStatusChangedEvent - when id == CEI_DeviceConnectionStatusChangedEvent
+    ///     contains valid pointer to structure with information about connected or disconnected device
+    /// const CorsairKeyEvent *keyEvent - when id == CEI_KeyEvent
+    ///     contains valid pointer to structure with information about pressed or released G, M or S button and device where this event happened
+    /// </summary>
+    internal CorsairEventUnion corsairEventUnion;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal sealed class CorsairEventUnion
+{
+    /// <summary>
+    /// Points to <see cref="CorsairDeviceConnectionStatusChangedEvent"/> if _CorsairEvent's id is CEI_DeviceConnectionStatusChangedEvent,
+    /// points to <see cref="CorsairKeyEvent"/> if _CorsairEvent's id is CEI_KeyEvent
+    /// </summary>
+    internal nint eventPointer;
+}
+

--- a/RGB.NET.Devices.Corsair/Native/_CorsairEvent.cs
+++ b/RGB.NET.Devices.Corsair/Native/_CorsairEvent.cs
@@ -22,22 +22,8 @@ internal sealed class _CorsairEvent
     internal CorsairEventId id;
 
     /// <summary>
-    /// iCUE-SDK: Anonymous union with fields:
-    /// const CorsairDeviceConnectionStatusChangedEvent *deviceConnectionStatusChangedEvent - when id == CEI_DeviceConnectionStatusChangedEvent
-    ///     contains valid pointer to structure with information about connected or disconnected device
-    /// const CorsairKeyEvent *keyEvent - when id == CEI_KeyEvent
-    ///     contains valid pointer to structure with information about pressed or released G, M or S button and device where this event happened
-    /// </summary>
-    internal CorsairEventUnion corsairEventUnion;
-}
-
-[StructLayout(LayoutKind.Sequential)]
-internal sealed class CorsairEventUnion
-{
-    /// <summary>
     /// Points to <see cref="CorsairDeviceConnectionStatusChangedEvent"/> if _CorsairEvent's id is CEI_DeviceConnectionStatusChangedEvent,
     /// points to <see cref="CorsairKeyEvent"/> if _CorsairEvent's id is CEI_KeyEvent
     /// </summary>
     internal nint eventPointer;
 }
-


### PR DESCRIPTION
After implementing the event and messing around I figured that sdk is designed in a way that all we have to do is react to the events. Device connect/disconnect events are thrown while initializing and disposing.

You can test the events by calling Provider.Initialize() in console application. I've also changed other parts of corsair and rgb.net.core to fully implement it and tested in Aurora.

I don't much experience with unsafe/unmanaged code so correct me if I coded incorrecly. I tried to encapsulate all unsafe code to native class.