### PR TITLE
made singleton device initializers thread-safe

### DIFF
--- a/RGB.NET.Devices.Asus/AsusDeviceProvider.cs
+++ b/RGB.NET.Devices.Asus/AsusDeviceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using AuraServiceLib;
 using RGB.NET.Core;
 
@@ -16,28 +17,14 @@ public sealed class AsusDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static AsusDeviceProvider? _instance;
+    private static Lazy<AsusDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="AsusDeviceProvider"/> instance.
     /// </summary>
-    public static AsusDeviceProvider Instance => _instance ?? new AsusDeviceProvider();
+    public static AsusDeviceProvider Instance => _instance.Value;
 
     private IAuraSdk2? _sdk;
     private IAuraSyncDeviceCollection? _devices; //HACK DarthAffe 05.04.2021: Due to some researches this might fix the access violation in the asus-sdk
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AsusDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public AsusDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(AsusDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.CoolerMaster/CoolerMasterDeviceProvider.cs
+++ b/RGB.NET.Devices.CoolerMaster/CoolerMasterDeviceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using RGB.NET.Core;
 using RGB.NET.Devices.CoolerMaster.Helper;
 using RGB.NET.Devices.CoolerMaster.Native;
@@ -17,11 +18,11 @@ public sealed class CoolerMasterDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static CoolerMasterDeviceProvider? _instance;
+    private static Lazy<CoolerMasterDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="CoolerMasterDeviceProvider"/> instance.
     /// </summary>
-    public static CoolerMasterDeviceProvider Instance => _instance ?? new CoolerMasterDeviceProvider();
+    public static CoolerMasterDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a modifiable list of paths used to find the native SDK-dlls for x86 applications.
@@ -34,20 +35,6 @@ public sealed class CoolerMasterDeviceProvider : AbstractRGBDeviceProvider
     /// The first match will be used.
     /// </summary>
     public static List<string> PossibleX64NativePaths { get; } = new() { "x64/CMSDK.dll" };
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CoolerMasterDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public CoolerMasterDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(CoolerMasterDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.Corsair/CorsairDeviceProvider.cs
+++ b/RGB.NET.Devices.Corsair/CorsairDeviceProvider.cs
@@ -17,11 +17,11 @@ public sealed class CorsairDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static CorsairDeviceProvider? _instance;
+    private static Lazy<CorsairDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="CorsairDeviceProvider"/> instance.
     /// </summary>
-    public static CorsairDeviceProvider Instance => _instance ?? new CorsairDeviceProvider();
+    public static CorsairDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a modifiable list of paths used to find the native SDK-dlls for x86 applications.
@@ -69,20 +69,6 @@ public sealed class CorsairDeviceProvider : AbstractRGBDeviceProvider
 
     // ReSharper disable once UnassignedField.Global
     public EventHandler<CorsairSessionState>? SessionStateChanged;
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CorsairDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public CorsairDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(CorsairDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.DMX/DMXDeviceProvider.cs
+++ b/RGB.NET.Devices.DMX/DMXDeviceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using RGB.NET.Core;
 using RGB.NET.Devices.DMX.E131;
 
@@ -16,30 +17,16 @@ public sealed class DMXDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static DMXDeviceProvider? _instance;
+    private static Lazy<DMXDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="DMXDeviceProvider"/> instance.
     /// </summary>
-    public static DMXDeviceProvider Instance => _instance ?? new DMXDeviceProvider();
+    public static DMXDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a list of all defined device-definitions.
     /// </summary>
     public List<IDMXDeviceDefinition> DeviceDefinitions { get; } = new();
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DMXDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public DMXDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(DMXDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.Debug/DebugDeviceProvider.cs
+++ b/RGB.NET.Devices.Debug/DebugDeviceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using RGB.NET.Core;
 using RGB.NET.Layout;
 
@@ -16,27 +17,13 @@ public sealed class DebugDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static DebugDeviceProvider? _instance;
+    private static Lazy<DebugDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="DebugDeviceProvider"/> instance.
     /// </summary>
-    public static DebugDeviceProvider Instance => _instance ?? new DebugDeviceProvider();
+    public static DebugDeviceProvider Instance => _instance.Value;
 
     private List<(IDeviceLayout layout, Action<IEnumerable<Led>>? updateLedsAction)> _fakeDeviceDefinitions = new();
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DebugDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public DebugDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(DebugDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
+++ b/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using HidSharp;
 using RGB.NET.Core;
 using RGB.NET.Devices.Logitech.Native;
@@ -20,11 +21,11 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static LogitechDeviceProvider? _instance;
+    private static Lazy<LogitechDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="LogitechDeviceProvider"/> instance.
     /// </summary>
-    public static LogitechDeviceProvider Instance => _instance ?? new LogitechDeviceProvider();
+    public static LogitechDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a modifiable list of paths used to find the native SDK-dlls for x86 applications.
@@ -153,20 +154,6 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
     /// Gets the HID-definitions for wireless per-device-devices.
     /// </summary>
     public static LightspeedHIDLoader<int, int> PerDeviceWirelessDeviceDefinitions { get; } = new();
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LogitechDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public LogitechDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(LogitechDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.Msi/MsiDeviceProvider.cs
+++ b/RGB.NET.Devices.Msi/MsiDeviceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using RGB.NET.Core;
 using RGB.NET.Devices.Msi.Exceptions;
 using RGB.NET.Devices.Msi.Native;
@@ -17,11 +18,11 @@ public class MsiDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static MsiDeviceProvider? _instance;
+    private static Lazy<MsiDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="MsiDeviceProvider"/> instance.
     /// </summary>
-    public static MsiDeviceProvider Instance => _instance ?? new MsiDeviceProvider();
+    public static MsiDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a modifiable list of paths used to find the native SDK-dlls for x86 applications.
@@ -34,20 +35,6 @@ public class MsiDeviceProvider : AbstractRGBDeviceProvider
     /// The first match will be used.
     /// </summary>
     public static List<string> PossibleX64NativePaths { get; } = new() { "x64/MysticLight_SDK.dll" };
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MsiDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public MsiDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(MsiDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.Novation/NovationDeviceProvider.cs
+++ b/RGB.NET.Devices.Novation/NovationDeviceProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using RGB.NET.Core;
 using Sanford.Multimedia.Midi;
 
@@ -17,25 +18,11 @@ public sealed class NovationDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static NovationDeviceProvider? _instance;
+    private static Lazy<NovationDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="NovationDeviceProvider"/> instance.
     /// </summary>
-    public static NovationDeviceProvider Instance => _instance ?? new NovationDeviceProvider();
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NovationDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    private NovationDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(NovationDeviceProvider)}");
-        _instance = this;
-    }
+    public static NovationDeviceProvider Instance => _instance.Value;
 
     #endregion
 

--- a/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
+++ b/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
@@ -3,6 +3,7 @@ using RGB.NET.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace RGB.NET.Devices.OpenRGB;
 
@@ -16,12 +17,12 @@ public sealed class OpenRGBDeviceProvider : AbstractRGBDeviceProvider
 
     private readonly List<OpenRgbClient> _clients = new();
 
-    private static OpenRGBDeviceProvider? _instance;
+    private static Lazy<OpenRGBDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
 
     /// <summary>
     /// Gets the singleton <see cref="OpenRGBDeviceProvider"/> instance.
     /// </summary>
-    public static OpenRGBDeviceProvider Instance => _instance ?? new OpenRGBDeviceProvider();
+    public static OpenRGBDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a list of all defined device-definitions.
@@ -37,20 +38,6 @@ public sealed class OpenRGBDeviceProvider : AbstractRGBDeviceProvider
     /// Defines which device types will be separated by zones. Defaults to <see cref="RGBDeviceType.LedStripe" /> | <see cref="RGBDeviceType.Mainboard"/> | <see cref="RGBDeviceType.Speaker" />.
     /// </summary>
     public RGBDeviceType PerZoneDeviceFlag { get; } = RGBDeviceType.LedStripe | RGBDeviceType.Mainboard | RGBDeviceType.Speaker;
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="OpenRGBDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public OpenRGBDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(OpenRGBDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.PicoPi/PicoPiDeviceProvider.cs
+++ b/RGB.NET.Devices.PicoPi/PicoPiDeviceProvider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using HidSharp;
 using RGB.NET.Core;
 using RGB.NET.Devices.PicoPi.Enum;
@@ -25,11 +26,11 @@ public sealed class PicoPiDeviceProvider : AbstractRGBDeviceProvider
 
     #region Properties & Fields
 
-    private static PicoPiDeviceProvider? _instance;
+    private static Lazy<PicoPiDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="PicoPiDeviceProvider"/> instance.
     /// </summary>
-    public static PicoPiDeviceProvider Instance => _instance ?? new PicoPiDeviceProvider();
+    public static PicoPiDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets the HID-definitions for PicoPi-devices.
@@ -46,20 +47,6 @@ public sealed class PicoPiDeviceProvider : AbstractRGBDeviceProvider
     /// If auto is set it automatically is using bulk-updates for devies with more than 40 LEDs if supported. Else HID is used.
     /// </summary>
     public UpdateMode UpdateMode { get; set; } = UpdateMode.Auto;
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PicoPiDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public PicoPiDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(PicoPiDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
+++ b/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using RGB.NET.Core;
 using RGB.NET.Devices.Razer.Native;
 using RGB.NET.HID;
@@ -19,11 +20,11 @@ public sealed class RazerDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static RazerDeviceProvider? _instance;
+    private static Lazy<RazerDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="RazerDeviceProvider"/> instance.
     /// </summary>
-    public static RazerDeviceProvider Instance => _instance ?? new RazerDeviceProvider();
+    public static RazerDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a modifiable list of paths used to find the native SDK-dlls for x86 applications.
@@ -235,20 +236,6 @@ public sealed class RazerDeviceProvider : AbstractRGBDeviceProvider
         { 0x0F1F, RGBDeviceType.LedController, "Addressable RGB Controller", LedMappings.ChromaLink, RazerEndpointType.ChromaLink },
         
     };
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RazerDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public RazerDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(RazerDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.SteelSeries/SteelSeriesDeviceProvider.cs
+++ b/RGB.NET.Devices.SteelSeries/SteelSeriesDeviceProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using RGB.NET.Core;
 using RGB.NET.Devices.SteelSeries.API;
 using RGB.NET.HID;
@@ -20,11 +21,11 @@ public sealed class SteelSeriesDeviceProvider : AbstractRGBDeviceProvider
 
     #region Properties & Fields
 
-    private static SteelSeriesDeviceProvider? _instance;
+    private static Lazy<SteelSeriesDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="SteelSeriesDeviceProvider"/> instance.
     /// </summary>
-    public static SteelSeriesDeviceProvider Instance => _instance ?? new SteelSeriesDeviceProvider();
+    public static SteelSeriesDeviceProvider Instance => _instance.Value;
 
     private const int VENDOR_ID = 0x1038;
 
@@ -82,20 +83,6 @@ public sealed class SteelSeriesDeviceProvider : AbstractRGBDeviceProvider
         //Monitors
         { 0x1126, RGBDeviceType.Monitor, "MGP27C", LedMappings.MonitorOnehundredandthreeZone, SteelSeriesDeviceType.OneHundredAndThreeZone },
     };
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SteelSeriesDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public SteelSeriesDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(SteelSeriesDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.WS281X/WS281XDeviceProvider.cs
+++ b/RGB.NET.Devices.WS281X/WS281XDeviceProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using RGB.NET.Core;
 
 namespace RGB.NET.Devices.WS281X;
@@ -16,11 +17,11 @@ public sealed class WS281XDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static WS281XDeviceProvider? _instance;
+    private static Lazy<WS281XDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="WS281XDeviceProvider"/> instance.
     /// </summary>
-    public static WS281XDeviceProvider Instance => _instance ?? new WS281XDeviceProvider();
+    public static WS281XDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a list of all defined device-definitions.
@@ -28,20 +29,6 @@ public sealed class WS281XDeviceProvider : AbstractRGBDeviceProvider
     // ReSharper disable once CollectionNeverUpdated.Global
     // ReSharper disable once ReturnTypeCanBeEnumerable.Global
     public List<IWS281XDeviceDefinition> DeviceDefinitions { get; } = new();
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="WS281XDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public WS281XDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(WS281XDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 

--- a/RGB.NET.Devices.Wooting/WootingDeviceProvider.cs
+++ b/RGB.NET.Devices.Wooting/WootingDeviceProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
 using RGB.NET.Core;
 using RGB.NET.Devices.Wooting.Generic;
 using RGB.NET.Devices.Wooting.Keyboard;
@@ -16,11 +17,11 @@ public sealed class WootingDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private static WootingDeviceProvider? _instance;
+    private static Lazy<WootingDeviceProvider> _instance = new(LazyThreadSafetyMode.ExecutionAndPublication);
     /// <summary>
     /// Gets the singleton <see cref="WootingDeviceProvider"/> instance.
     /// </summary>
-    public static WootingDeviceProvider Instance => _instance ?? new WootingDeviceProvider();
+    public static WootingDeviceProvider Instance => _instance.Value;
 
     /// <summary>
     /// Gets a modifiable list of paths used to find the native SDK-dlls for x86 windows applications.
@@ -46,20 +47,6 @@ public sealed class WootingDeviceProvider : AbstractRGBDeviceProvider
     /// </summary>
     // ReSharper disable once InconsistentNaming
     public static List<string> PossibleNativePathsMacOS { get; } = new() { "x64/libwooting-rgb-sdk.dylib" };
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="WootingDeviceProvider"/> class.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if this constructor is called even if there is already an instance of this class.</exception>
-    public WootingDeviceProvider()
-    {
-        if (_instance != null) throw new InvalidOperationException($"There can be only one instance of type {nameof(WootingDeviceProvider)}");
-        _instance = this;
-    }
 
     #endregion
 


### PR DESCRIPTION
I've had a small issue and thought it could be because of race-conditions. Current provider initializations are not thread-safe.

I've used Lazy<> class for this PR. Even just initializing on static fields would be better than current one.