### PR TITLE
Openrgb device updated implementation

### DIFF
--- a/RGB.NET.Devices.OpenRGB/Abstract/AbstractOpenRGBDevice.cs
+++ b/RGB.NET.Devices.OpenRGB/Abstract/AbstractOpenRGBDevice.cs
@@ -21,4 +21,23 @@ public abstract class AbstractOpenRGBDevice<TDeviceInfo> : AbstractRGBDevice<TDe
     { }
 
     #endregion
+
+    #region Methods
+
+    private bool Equals(AbstractOpenRGBDevice<TDeviceInfo> other)
+    {
+        return DeviceInfo.DeviceName == other.DeviceInfo.DeviceName;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return ReferenceEquals(this, obj) || (obj is AbstractOpenRGBDevice<TDeviceInfo> other && Equals(other));
+    }
+
+    public override int GetHashCode()
+    {
+        return DeviceInfo.DeviceName.GetHashCode();
+    }
+
+    #endregion
 }

--- a/RGB.NET.Devices.OpenRGB/Abstract/OpenRGBDeviceInfo.cs
+++ b/RGB.NET.Devices.OpenRGB/Abstract/OpenRGBDeviceInfo.cs
@@ -38,14 +38,17 @@ public class OpenRGBDeviceInfo : IRGBDeviceInfo
     /// Initializes a new instance of <see cref="OpenRGBDeviceInfo"/>.
     /// </summary>
     /// <param name="openRGBDevice">The OpenRGB device to extract information from.</param>
-    internal OpenRGBDeviceInfo(OpenRGBDevice openRGBDevice)
+    /// <param name="splitId">If this is a zone or segment, specify the name</param>
+    internal OpenRGBDeviceInfo(OpenRGBDevice openRGBDevice, string? splitId = null)
     {
         this.OpenRGBDevice = openRGBDevice;
 
         DeviceType = Helper.GetRgbNetDeviceType(openRGBDevice.Type);
         Manufacturer = Helper.GetVendorName(openRGBDevice);
         Model = Helper.GetModelName(openRGBDevice);
-        DeviceName = DeviceHelper.CreateDeviceName(Manufacturer, Model);
+        string model = Manufacturer + " " + Model;
+        string id = string.IsNullOrWhiteSpace(openRGBDevice.Serial) ? openRGBDevice.Location : openRGBDevice.Serial;
+        DeviceName = model + " #" + Helper.HashAndShorten(id) + (splitId != null ? $" {splitId}" : null);
     }
 
     #endregion

--- a/RGB.NET.Devices.OpenRGB/Generic/OpenRGBUpdateQueue.cs
+++ b/RGB.NET.Devices.OpenRGB/Generic/OpenRGBUpdateQueue.cs
@@ -18,7 +18,7 @@ public sealed class OpenRGBUpdateQueue : UpdateQueue
 
     private readonly int _deviceId;
 
-    private readonly OpenRgbClient _openRGB;
+    private readonly IOpenRgbClient _openRGB;
     private readonly OpenRGBColor[] _colors;
 
     #endregion
@@ -32,7 +32,7 @@ public sealed class OpenRGBUpdateQueue : UpdateQueue
     /// <param name="deviceId">The index used to identify the device.</param>
     /// <param name="client">The OpenRGB client used to send updates to the OpenRGB server.</param>
     /// <param name="device">The OpenRGB Device containing device-specific information.</param>
-    public OpenRGBUpdateQueue(IDeviceUpdateTrigger updateTrigger, int deviceId, OpenRgbClient client, OpenRGBDevice device)
+    public OpenRGBUpdateQueue(IDeviceUpdateTrigger updateTrigger, int deviceId, IOpenRgbClient client, OpenRGBDevice device)
         : base(updateTrigger)
     {
         this._deviceId = deviceId;

--- a/RGB.NET.Devices.OpenRGB/Helper.cs
+++ b/RGB.NET.Devices.OpenRGB/Helper.cs
@@ -1,4 +1,7 @@
-﻿using OpenRGB.NET;
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using OpenRGB.NET;
 using RGB.NET.Core;
 using OpenRGBDevice = OpenRGB.NET.Device;
 
@@ -53,4 +56,20 @@ internal static class Helper
     public static string GetModelName(OpenRGBDevice openRGBDevice) => string.IsNullOrWhiteSpace(openRGBDevice.Vendor)
                                                                           ? openRGBDevice.Name
                                                                           : openRGBDevice.Name.Replace(openRGBDevice.Vendor, "").Trim();
+    
+    internal static string HashAndShorten(string input)
+    {
+        using SHA256 sha256Hash = SHA256.Create();
+        byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(input));
+        // Take the first 4 bytes of the hash
+        byte[] shortenedBytes = new byte[4];
+        Array.Copy(bytes, shortenedBytes, 4);
+        // Convert the bytes to a string
+        StringBuilder shortenedHash = new();
+        foreach (byte b in shortenedBytes)
+        {
+            shortenedHash.Append(b.ToString("X2"));
+        }
+        return shortenedHash.ToString();
+    }
 }

--- a/RGB.NET.Devices.OpenRGB/OpenRGBClientWrapper.cs
+++ b/RGB.NET.Devices.OpenRGB/OpenRGBClientWrapper.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using OpenRGB.NET;
+using RGB.NET.Core;
+
+namespace RGB.NET.Devices.OpenRGB;
+
+public class OpenRGBClientWrapper
+{
+    public OpenRgbClient OpenRgbClient { get; }
+
+    public List<IRGBDevice> Devices { get; } = new();
+
+    public OpenRGBClientWrapper(OpenRgbClient openRgbClient)
+    {
+        OpenRgbClient = openRgbClient;
+    }
+
+    public void Dispose()
+    {
+        OpenRgbClient.Dispose();
+    }
+}

--- a/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
+++ b/RGB.NET.Devices.OpenRGB/OpenRGBDeviceProvider.cs
@@ -1,8 +1,9 @@
-using OpenRGB.NET;
 using RGB.NET.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRGB.NET;
+using OpenRgbDevice = OpenRGB.NET.Device;
 
 namespace RGB.NET.Devices.OpenRGB;
 
@@ -14,7 +15,7 @@ public sealed class OpenRGBDeviceProvider : AbstractRGBDeviceProvider
 {
     #region Properties & Fields
 
-    private readonly List<OpenRgbClient> _clients = new();
+    private readonly List<OpenRGBClientWrapper> _clients = new();
 
     private static OpenRGBDeviceProvider? _instance;
 
@@ -71,7 +72,9 @@ public sealed class OpenRGBDeviceProvider : AbstractRGBDeviceProvider
             try
             {
                 OpenRgbClient openRgb = new(ip: deviceDefinition.Ip, port: deviceDefinition.Port, name: deviceDefinition.ClientName, autoConnect: true);
-                _clients.Add(openRgb);
+                OpenRGBClientWrapper wrapper = new(openRgb);
+                openRgb.DeviceListUpdated += (_, _) => RefreshClient(wrapper);
+                _clients.Add(wrapper);
                 deviceDefinition.Connected = true;
             }
             catch (Exception e)
@@ -82,67 +85,104 @@ public sealed class OpenRGBDeviceProvider : AbstractRGBDeviceProvider
             }
         }
     }
+    
+    private void RefreshClient(OpenRGBClientWrapper openRgbClient)
+    {
+        List<IRGBDevice> currentDevices = new(openRgbClient.Devices);
+        List<IRGBDevice> newDevices = GetOrgbClientDevices(openRgbClient.OpenRgbClient)
+                                      .SelectMany((device, i) => SplitDevice(device, i, openRgbClient.OpenRgbClient)).ToList();
+        
+        foreach (IRGBDevice rgbDevice in currentDevices.Except(newDevices))
+        {
+            RemoveDevice(rgbDevice); 
+            openRgbClient.Devices.Remove(rgbDevice);
+        }
+        foreach (IRGBDevice rgbDevice in newDevices)
+        {
+            openRgbClient.Devices.Add(rgbDevice);
+            AddDevice(rgbDevice);
+        }
+    }
 
     /// <inheritdoc />
     protected override IEnumerable<IRGBDevice> LoadDevices()
     {
-        foreach (OpenRgbClient? openRgb in _clients)
+        return _clients.SelectMany(LoadClientDevices);
+    }
+
+    private IEnumerable<IRGBDevice> LoadClientDevices(OpenRGBClientWrapper client)
+    {
+        List<IRGBDevice> devices = GetOrgbClientDevices(client.OpenRgbClient)
+                                   .SelectMany((device, i) => SplitDevice(device, i, client.OpenRgbClient))
+                                   .ToList();
+        client.Devices.AddRange(devices);
+        return devices;
+    }
+
+    private IEnumerable<OpenRgbDevice> GetOrgbClientDevices(IOpenRgbClient openRgb)
+    {
+        int deviceCount = openRgb.GetControllerCount();
+
+        for (int i = 0; i < deviceCount; i++)
         {
-            int deviceCount = openRgb.GetControllerCount();
+            OpenRgbDevice device = openRgb.GetControllerData(i);
 
-            for (int i = 0; i < deviceCount; i++)
+            int directModeIndex = Array.FindIndex(device.Modes, d => d.Name == "Direct");
+            if (directModeIndex != -1)
             {
-                Device device = openRgb.GetControllerData(i);
+                //set the device to direct mode if it has it
+                openRgb.UpdateMode(i, directModeIndex);
+            }
+            else if (!ForceAddAllDevices)
+            {
+                //if direct mode does not exist
+                //and if we're not forcing, continue to the next device.
+                continue;
+            }
 
-                int directModeIndex = Array.FindIndex(device.Modes, d => d.Name == "Direct");
-                if (directModeIndex != -1)
+            if (device.Zones.Length == 0)
+                continue;
+            if (device.Zones.All(z => z.LedCount == 0))
+                continue;
+
+            yield return device;
+        }
+    }
+
+    private IEnumerable<IRGBDevice> SplitDevice(OpenRgbDevice device, int i, IOpenRgbClient openRgb)
+    {
+        IDeviceUpdateTrigger clientUpdateTrigger = GetUpdateTrigger();
+        OpenRGBUpdateQueue updateQueue = new(clientUpdateTrigger, i, openRgb, device);
+
+        bool anyZoneHasSegments = device.Zones.Any(z => z.Segments.Length > 0);
+        bool splitDeviceByZones = anyZoneHasSegments || PerZoneDeviceFlag.HasFlag(Helper.GetRgbNetDeviceType(device.Type));
+
+        if (!splitDeviceByZones)
+        {
+            yield return new OpenRGBGenericDevice(new OpenRGBDeviceInfo(device), updateQueue);
+            yield break;
+        }
+
+        int totalLedCount = 0;
+
+        foreach (Zone zone in device.Zones)
+        {
+            if (zone.LedCount <= 0)
+                continue;
+
+            if (zone.Segments.Length <= 0)
+            {
+                string zoneId = zone.Name;
+                yield return new OpenRGBZoneDevice(new OpenRGBDeviceInfo(device, zoneId), totalLedCount, zone, updateQueue);
+                totalLedCount += (int)zone.LedCount;
+            }
+            else
+            {
+                foreach (Segment segment in zone.Segments)
                 {
-                    //set the device to direct mode if it has it
-                    openRgb.UpdateMode(i, directModeIndex);
-                }
-                else if (!ForceAddAllDevices)
-                {
-                    //if direct mode does not exist
-                    //and if we're not forcing, continue to the next device.
-                    continue;
-                }
-
-                if (device.Zones.Length == 0) 
-                    continue;
-                if (device.Zones.All(z => z.LedCount == 0)) 
-                    continue;
-
-                OpenRGBUpdateQueue updateQueue = new(GetUpdateTrigger(), i, openRgb, device);
-                
-                bool anyZoneHasSegments = device.Zones.Any(z => z.Segments.Length > 0);
-                bool splitDeviceByZones = anyZoneHasSegments ||  PerZoneDeviceFlag.HasFlag(Helper.GetRgbNetDeviceType(device.Type));
-
-                if (!splitDeviceByZones)
-                {
-                    yield return new OpenRGBGenericDevice(new OpenRGBDeviceInfo(device), updateQueue);
-                    continue;
-                }
-                
-                int totalLedCount = 0;
-
-                foreach (Zone zone in device.Zones)
-                {
-                    if (zone.LedCount <= 0)
-                        continue;
-
-                    if (zone.Segments.Length <= 0)
-                    {
-                        yield return new OpenRGBZoneDevice(new OpenRGBDeviceInfo(device), totalLedCount, zone, updateQueue);
-                        totalLedCount += (int)zone.LedCount;
-                    }
-                    else
-                    {
-                        foreach (Segment segment in zone.Segments)
-                        {
-                            yield return new OpenRGBSegmentDevice(new OpenRGBDeviceInfo(device), totalLedCount, segment, updateQueue);
-                            totalLedCount += (int)segment.LedCount;
-                        }
-                    }
+                    string zoneId = segment.Name;
+                    yield return new OpenRGBSegmentDevice(new OpenRGBDeviceInfo(device, zoneId), totalLedCount, segment, updateQueue);
+                    totalLedCount += (int)segment.LedCount;
                 }
             }
         }
@@ -153,9 +193,9 @@ public sealed class OpenRGBDeviceProvider : AbstractRGBDeviceProvider
     {
         base.Dispose();
 
-        foreach (OpenRgbClient client in _clients)
+        foreach (OpenRGBClientWrapper wrapper in _clients)
         {
-            try { client.Dispose(); }
+            try { wrapper.Dispose(); }
             catch { /* at least we tried */ }
         }
 


### PR DESCRIPTION
This PR adds DevicesChanged implementation for OpenRgb library.

# Breaking Changes
- Device names

Previously device names were created different each time, adding number in a paranthesis in their names. This caused problems when devices were reconnected or while checking if the device is new or not.

My proposal is adding a hash to the Device Names based on serial or device location (for internal devices). For zones and segments, their zone or segment name is also appended and not using incremental numbers in Device Names

This is a draft PR because I haven't tested with Aurora yet.