### PR TITLE
Added Razer Blade 16 PID

### DIFF
--- a/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
+++ b/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
@@ -127,6 +127,7 @@ public sealed class RazerDeviceProvider : AbstractRGBDeviceProvider
         { 0x028A, RGBDeviceType.Keyboard, "Blade 15 Advanced (Early 2022)", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x028B, RGBDeviceType.Keyboard, "Blade 17 (2022)", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x028C, RGBDeviceType.Keyboard, "Blade 14 (2022)", LedMappings.Keyboard, RazerEndpointType.Keyboard },
+        { 0x029F, RGBDeviceType.Keyboard, "Blade 16 (2023)", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x028D, RGBDeviceType.Keyboard, "BlackWidow V4", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x0290, RGBDeviceType.Keyboard, "DeathStalker V2 Pro", LedMappings.Keyboard, RazerEndpointType.Keyboard }, // Wireless
         { 0x0292, RGBDeviceType.Keyboard, "DeathStalker V2 Pro", LedMappings.Keyboard, RazerEndpointType.Keyboard }, // Wired


### PR DESCRIPTION
Adds the PID for the 2023 Razer Blade 16.
Tested with ArtemisRGB.
A few small things to note is that bindings don't appear to be completely correct, regardless of Keyboard or LaptopKeyboard types.
For example the keys: alt, right alt, fn, enter, F1 and right shift don't appear to light (tested with the international/us model).