### PR TITLE
set ThrowsExceptions false after initialization

### DIFF
--- a/RGB.NET.Core/Devices/AbstractRGBDeviceProvider.cs
+++ b/RGB.NET.Core/Devices/AbstractRGBDeviceProvider.cs
@@ -100,6 +100,10 @@ public abstract class AbstractRGBDeviceProvider : IRGBDeviceProvider
             Throw(ex, true);
             return false;
         }
+        finally
+        {
+            ThrowsExceptions = false;
+        }
 
         return true;
     }


### PR DESCRIPTION
Problem:
When provider is initialized with throwExceptions = true, UpdateQueue throws exceptions in thread-pool and crashes application

Hopefully this is an acceptable solution.