### PR TITLE
added Num/Caps/Scroll lock indicator mappings to OpenRGB

### DIFF
--- a/RGB.NET.Devices.OpenRGB/Generic/LedMappings.cs
+++ b/RGB.NET.Devices.OpenRGB/Generic/LedMappings.cs
@@ -141,5 +141,8 @@ internal static class LedMappings
         ["Key: G9"] = LedId.Keyboard_Programmable9,
         ["Lighting"] = LedId.Keyboard_Brightness,
         ["Game Mode"] = LedId.Keyboard_WinLock,
+        ["Num Lock Indicator"] = LedId.Keyboard_IndicatorNumLock,
+        ["Caps Lock Indicator"] = LedId.Keyboard_IndicatorCapsLock,
+        ["Scroll Lock Indicator"] = LedId.Keyboard_IndicatorScrollLock,
     };
 }


### PR DESCRIPTION
3 main indicator led mappings for OpenRGB

Led name reference:
https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/Controllers/LogitechController/RGBController_LogitechG810.cpp#L163