### PR TITLE
Call LogiLedShutdown on Logitech provider dispose

### DIFF
--- a/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
+++ b/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
@@ -277,6 +277,9 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
             try { _LogitechGSDK.LogiLedRestoreLighting(); }
             catch { /* at least we tried */ }
 
+            try { _LogitechGSDK.LogiLedShutdown(); }
+            catch { /* at least we tried */ }
+
             try { _LogitechGSDK.UnloadLogitechGSDK(); }
             catch { /* at least we tried */ }
 


### PR DESCRIPTION
Not calling LogiLedShutdown keeps the integration up and it fails on next start