### PR TITLE
Razer: Load Debug Device Properties for Each Device Type

### DIFF
--- a/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
+++ b/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
@@ -52,6 +52,36 @@ public sealed class RazerDeviceProvider : AbstractRGBDeviceProvider
     /// </summary>
     public bool LoadEmulatorDevices { get; set; } = false;
 
+    /// <summary>
+    /// Forces to load keyboard represented by the emulator if they aren't reported to exist.
+    /// </summary>
+    public bool LoadKeyboardEmulator { get; set; } = false;
+
+    /// <summary>
+    /// Forces to load mouse represented by the emulator if they aren't reported to exist.
+    /// </summary>
+    public bool LoadMouseEmulator { get; set; } = false;
+
+    /// <summary>
+    /// Forces to load headset represented by the emulator if they aren't reported to exist.
+    /// </summary>
+    public bool LoadHeadsetEmulator { get; set; } = false;
+
+    /// <summary>
+    /// Forces to load mosuepad represented by the emulator if they aren't reported to exist.
+    /// </summary>
+    public bool LoadMousepadEmulator { get; set; } = false;
+
+    /// <summary>
+    /// Forces to load keypad represented by the emulator if they aren't reported to exist.
+    /// </summary>
+    public bool LoadKeypadEmulator { get; set; } = false;
+
+    /// <summary>
+    /// Forces to load link device represented by the emulator if they aren't reported to exist.
+    /// </summary>
+    public bool LoadLinkEmulator { get; set; } = false;
+
     private const int VENDOR_ID = 0x1532;
 
     /// <summary>
@@ -315,20 +345,34 @@ public sealed class RazerDeviceProvider : AbstractRGBDeviceProvider
 
         IList<IRGBDevice> devices = base.GetLoadedDevices(loadFilter).ToList();
 
-        if (LoadEmulatorDevices)
+        if ((LoadEmulatorDevices || LoadKeyboardEmulator) && loadFilter.HasFlag(RGBDeviceType.Keyboard) && !devices.Any(d => d is RazerKeyboardRGBDevice))
         {
-            if (loadFilter.HasFlag(RGBDeviceType.Keyboard) && devices.All(d => d is not RazerKeyboardRGBDevice))
-                devices.Add(new RazerKeyboardRGBDevice(new RazerKeyboardRGBDeviceInfo("Emulator Keyboard", RazerEndpointType.Keyboard), GetUpdateTrigger(), LedMappings.Keyboard));
-            if (loadFilter.HasFlag(RGBDeviceType.Mouse) && devices.All(d => d is not RazerMouseRGBDevice))
-                devices.Add(new RazerMouseRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Mouse, RazerEndpointType.Mouse, "Emulator Mouse"), GetUpdateTrigger(), LedMappings.Mouse));
-            if (loadFilter.HasFlag(RGBDeviceType.Headset) && devices.All(d => d is not RazerHeadsetRGBDevice))
-                devices.Add(new RazerHeadsetRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Headset, RazerEndpointType.Headset, "Emulator Headset"), GetUpdateTrigger()));
-            if (loadFilter.HasFlag(RGBDeviceType.Mousepad) && devices.All(d => d is not RazerMousepadRGBDevice))
-                devices.Add(new RazerMousepadRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Mousepad, RazerEndpointType.Mousepad, "Emulator Mousepad"), GetUpdateTrigger()));
-            if (loadFilter.HasFlag(RGBDeviceType.Keypad) && devices.All(d => d is not RazerMousepadRGBDevice))
-                devices.Add(new RazerKeypadRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Keypad, RazerEndpointType.Keypad, "Emulator Keypad"), GetUpdateTrigger()));
-            if (loadFilter.HasFlag(RGBDeviceType.Unknown) && devices.All(d => d is not RazerChromaLinkRGBDevice))
-                devices.Add(new RazerChromaLinkRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Unknown, RazerEndpointType.ChromaLink, "Emulator Chroma Link"), GetUpdateTrigger()));
+            devices.Add(new RazerKeyboardRGBDevice(new RazerKeyboardRGBDeviceInfo("Emulator Keyboard", RazerEndpointType.Keyboard), GetUpdateTrigger(), LedMappings.Keyboard));
+        }
+
+        if ((LoadEmulatorDevices || LoadMouseEmulator) && loadFilter.HasFlag(RGBDeviceType.Mouse) && !devices.Any(d => d is RazerMouseRGBDevice))
+        {
+            devices.Add(new RazerMouseRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Mouse, RazerEndpointType.Mouse, "Emulator Mouse"), GetUpdateTrigger(), LedMappings.Mouse));
+        }
+
+        if ((LoadEmulatorDevices || LoadHeadsetEmulator) && loadFilter.HasFlag(RGBDeviceType.Headset) && !devices.Any(d => d is RazerHeadsetRGBDevice))
+        {
+            devices.Add(new RazerHeadsetRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Headset, RazerEndpointType.Headset, "Emulator Headset"), GetUpdateTrigger()));
+        }
+
+        if ((LoadEmulatorDevices || LoadMousepadEmulator) && loadFilter.HasFlag(RGBDeviceType.Mousepad) && !devices.Any(d => d is RazerMousepadRGBDevice))
+        {
+            devices.Add(new RazerMousepadRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Mousepad, RazerEndpointType.Mousepad, "Emulator Mousepad"), GetUpdateTrigger()));
+        }
+
+        if ((LoadEmulatorDevices || LoadKeypadEmulator) && loadFilter.HasFlag(RGBDeviceType.Keypad) && !devices.Any(d => d is RazerMousepadRGBDevice))
+        {
+            devices.Add(new RazerKeypadRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Keypad, RazerEndpointType.Keypad, "Emulator Keypad"), GetUpdateTrigger()));
+        }
+
+        if ((LoadEmulatorDevices || LoadLinkEmulator) && loadFilter.HasFlag(RGBDeviceType.Unknown) && !devices.Any(d => d is RazerChromaLinkRGBDevice))
+        {
+            devices.Add(new RazerChromaLinkRGBDevice(new RazerRGBDeviceInfo(RGBDeviceType.Unknown, RazerEndpointType.ChromaLink, "Emulator Chroma Link"), GetUpdateTrigger()));
         }
 
         return devices;


### PR DESCRIPTION
This PR adds LoadX properties for each type of razer device.

This is something needed for people that use non-usb devices (like Phillips devices trough Chroma Connect) but they have to manually enable one of these.

Let me know if you need anything changed or create your changes with similar output