### PR TITLE
Add Wooting 80HE support

### DIFF
--- a/RGB.NET.Devices.Wooting/Enum/WootingDeviceType.cs
+++ b/RGB.NET.Devices.Wooting/Enum/WootingDeviceType.cs
@@ -26,4 +26,9 @@ public enum WootingDeviceType
     /// Three key keypad. E.g. Wooting Uwu
     /// </summary>
     Keypad3Keys = 4,
+    
+    /// <summary>
+    /// 80 percent keyboard. E.g. Wooting 80HE
+    /// </summary>
+    KeyboardEightyPercent = 5,
 }

--- a/RGB.NET.Devices.Wooting/Generic/WootingLedMappings.cs
+++ b/RGB.NET.Devices.Wooting/Generic/WootingLedMappings.cs
@@ -110,6 +110,105 @@ internal static class WootingLedMappings
         { LedId.Keyboard_ArrowDown, (5, 15) },
         { LedId.Keyboard_ArrowRight, (5, 16) }
     };
+    
+    private static readonly Dictionary<LedId, (int row, int column)> EightyPercent = new()
+    {
+        { LedId.Keyboard_Escape, (0, 0) },
+        { LedId.Keyboard_F1, (0, 1) },
+        { LedId.Keyboard_F2, (0, 2) },
+        { LedId.Keyboard_F3, (0, 3) },
+        { LedId.Keyboard_F4, (0, 4) },
+        { LedId.Keyboard_F5, (0, 5) },
+        { LedId.Keyboard_F6, (0, 6) },
+        { LedId.Keyboard_F7, (0, 7) },
+        { LedId.Keyboard_F8, (0, 8) },
+        { LedId.Keyboard_F9, (0, 10) },
+        { LedId.Keyboard_F10, (0, 11) },
+        { LedId.Keyboard_F11, (0, 12) },
+        { LedId.Keyboard_F12, (0, 13) },
+        { LedId.Keyboard_Custom1, (0, 14) },
+        { LedId.Keyboard_PrintScreen, (0, 15) },
+        { LedId.Keyboard_PauseBreak, (0, 16) },
+
+        { LedId.Keyboard_GraveAccentAndTilde, (1, 0) },
+        { LedId.Keyboard_1, (1, 1) },
+        { LedId.Keyboard_2, (1, 2) },
+        { LedId.Keyboard_3, (1, 3) },
+        { LedId.Keyboard_4, (1, 4) },
+        { LedId.Keyboard_5, (1, 5) },
+        { LedId.Keyboard_6, (1, 6) },
+        { LedId.Keyboard_7, (1, 7) },
+        { LedId.Keyboard_8, (1, 8) },
+        { LedId.Keyboard_9, (1, 9) },
+        { LedId.Keyboard_0, (1, 10) },
+        { LedId.Keyboard_MinusAndUnderscore, (1, 11) },
+        { LedId.Keyboard_EqualsAndPlus, (1, 12) },
+        { LedId.Keyboard_International1, (1, 13) },//JIS key
+        { LedId.Keyboard_Backspace, (1, 14) },
+        { LedId.Keyboard_Insert, (1, 15) },
+        { LedId.Keyboard_Home, (1, 16) },
+
+        { LedId.Keyboard_Tab, (2, 0) },
+        { LedId.Keyboard_Q, (2, 1) },
+        { LedId.Keyboard_W, (2, 2) },
+        { LedId.Keyboard_E, (2, 3) },
+        { LedId.Keyboard_R, (2, 4) },
+        { LedId.Keyboard_T, (2, 5) },
+        { LedId.Keyboard_Y, (2, 6) },
+        { LedId.Keyboard_U, (2, 7) },
+        { LedId.Keyboard_I, (2, 8) },
+        { LedId.Keyboard_O, (2, 9) },
+        { LedId.Keyboard_P, (2, 10) },
+        { LedId.Keyboard_BracketLeft, (2, 11) },
+        { LedId.Keyboard_BracketRight, (2, 12) },
+        { LedId.Keyboard_Backslash, (2, 14) },
+        { LedId.Keyboard_Delete, (2, 15) },
+        { LedId.Keyboard_End, (2, 16) },
+
+        { LedId.Keyboard_CapsLock, (3, 0) },
+        { LedId.Keyboard_A, (3, 1) },
+        { LedId.Keyboard_S, (3, 2) },
+        { LedId.Keyboard_D, (3, 3) },
+        { LedId.Keyboard_F, (3, 4) },
+        { LedId.Keyboard_G, (3, 5) },
+        { LedId.Keyboard_H, (3, 6) },
+        { LedId.Keyboard_J, (3, 7) },
+        { LedId.Keyboard_K, (3, 8) },
+        { LedId.Keyboard_L, (3, 9) },
+        { LedId.Keyboard_SemicolonAndColon, (3, 10) },
+        { LedId.Keyboard_ApostropheAndDoubleQuote, (3, 11) },
+        { LedId.Keyboard_NonUsTilde, (3, 12) },
+        { LedId.Keyboard_Enter, (3, 14) },
+
+        { LedId.Keyboard_LeftShift, (4, 0) },
+        { LedId.Keyboard_NonUsBackslash, (4, 1) },
+        { LedId.Keyboard_Z, (4, 2) },
+        { LedId.Keyboard_X, (4, 3) },
+        { LedId.Keyboard_C, (4, 4) },
+        { LedId.Keyboard_V, (4, 5) },
+        { LedId.Keyboard_B, (4, 6) },
+        { LedId.Keyboard_N, (4, 7) },
+        { LedId.Keyboard_M, (4, 8) },
+        { LedId.Keyboard_CommaAndLessThan, (4, 9) },
+        { LedId.Keyboard_PeriodAndBiggerThan, (4, 10) },
+        { LedId.Keyboard_SlashAndQuestionMark, (4, 11) },
+        { LedId.Keyboard_International2, (4, 13) },//JIS key
+        { LedId.Keyboard_RightShift, (4, 14) },
+        { LedId.Keyboard_ArrowUp, (4, 15) },
+
+        { LedId.Keyboard_LeftCtrl, (5, 0) },
+        { LedId.Keyboard_LeftGui, (5, 1) },
+        { LedId.Keyboard_LeftAlt, (5, 2) },
+        { LedId.Keyboard_International3, (4, 3) },//JIS key
+        { LedId.Keyboard_Space, (5, 6) },
+        { LedId.Keyboard_International4, (4, 9) },//JIS key
+        { LedId.Keyboard_RightAlt, (5, 10) },
+        { LedId.Keyboard_RightGui, (5, 11) },
+        { LedId.Keyboard_Function, (5, 12) },
+        { LedId.Keyboard_ArrowLeft, (5, 14) },
+        { LedId.Keyboard_ArrowDown, (5, 15) },
+        { LedId.Keyboard_ArrowRight, (5, 16) }
+    };
 
     private static readonly Dictionary<LedId, (int row, int column)> Fullsize = new()
     {
@@ -343,7 +442,8 @@ internal static class WootingLedMappings
         [WootingDeviceType.Keyboard] = Fullsize,
         [WootingDeviceType.KeyboardTKL] = TKL,
         [WootingDeviceType.KeyboardSixtyPercent] = SixtyPercent,
-        [WootingDeviceType.Keypad3Keys] = ThreeKeyKeypad
+        [WootingDeviceType.Keypad3Keys] = ThreeKeyKeypad,
+        [WootingDeviceType.KeyboardEightyPercent] = EightyPercent
     };
 
     #endregion


### PR DESCRIPTION
Unreleased keyboard, testing has been done with a pre-production sample. The wooting rgb sdk with support has not been released yet but this PR is backwards compatible and should work fine with current or older sdks.