### PR TITLE
Remove CustomUpdateData heap allocation in OnUpdate hot path.

### DIFF
--- a/RGB.NET.Core/Update/AbstractUpdateTrigger.cs
+++ b/RGB.NET.Core/Update/AbstractUpdateTrigger.cs
@@ -29,13 +29,13 @@ public abstract class AbstractUpdateTrigger : AbstractBindable, IUpdateTrigger
     /// Invokes the <see cref="Starting"/>-event.
     /// </summary>
     /// <param name="updateData">Optional custom-data passed to the subscribers of the <see cref="Starting"/>.event.</param>
-    protected virtual void OnStartup(CustomUpdateData? updateData = null) => Starting?.Invoke(this, updateData ?? new CustomUpdateData());
+    protected virtual void OnStartup(CustomUpdateData? updateData = null) => Starting?.Invoke(this, updateData ?? CustomUpdateData.Empty);
 
     /// <summary>
     /// Invokes the <see cref="Update"/>-event.
     /// </summary>
     /// <param name="updateData">Optional custom-data passed to the subscribers of the <see cref="Update"/>.event.</param>
-    protected virtual void OnUpdate(CustomUpdateData? updateData = null) => Update?.Invoke(this, updateData ?? new CustomUpdateData());
+    protected virtual void OnUpdate(CustomUpdateData? updateData = null) => Update?.Invoke(this, updateData ?? CustomUpdateData.Empty);
 
     /// <inheritdoc />
     public abstract void Start();

--- a/RGB.NET.Core/Update/CustomUpdateData.cs
+++ b/RGB.NET.Core/Update/CustomUpdateData.cs
@@ -51,7 +51,9 @@ public interface ICustomUpdateData
 public sealed class CustomUpdateData : ICustomUpdateData
 {
     #region Properties & Fields
-    public static readonly CustomUpdateData Empty = new CustomUpdateData();
+
+    // ReSharper disable once InconsistentNaming
+    public static readonly CustomUpdateData Empty = new();
 
     private readonly Dictionary<string, object?> _data = [];
 

--- a/RGB.NET.Core/Update/CustomUpdateData.cs
+++ b/RGB.NET.Core/Update/CustomUpdateData.cs
@@ -51,6 +51,7 @@ public interface ICustomUpdateData
 public sealed class CustomUpdateData : ICustomUpdateData
 {
     #region Properties & Fields
+    public static readonly CustomUpdateData Empty = new CustomUpdateData();
 
     private readonly Dictionary<string, object?> _data = [];
 


### PR DESCRIPTION
This change removes heap allocation of CustomUpdateData in the OnUpdate hot path when custom data does not exist.   A read-only CustomUpdateData.Empty property is added to reuse a default instance and remove a per-update allocation.