### PR TITLE
Adding Razer Huntsman V3 Pro

### DIFF
--- a/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
+++ b/RGB.NET.Devices.Razer/RazerDeviceProvider.cs
@@ -151,6 +151,7 @@ public sealed class RazerDeviceProvider : AbstractRGBDeviceProvider
         { 0x02A0, RGBDeviceType.Keyboard, "Blade 18", LedMappings.Blade, RazerEndpointType.Keyboard },
         { 0x02A1, RGBDeviceType.Keyboard, "Ornata V3", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x02A5, RGBDeviceType.Keyboard, "BlackWidow V4 75%", LedMappings.Keyboard, RazerEndpointType.Keyboard },
+        { 0x02A6, RGBDeviceType.Keyboard, "Huntsman V3 Pro", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x02A7, RGBDeviceType.Keyboard, "Huntsman V3 Pro TKL", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x0A24, RGBDeviceType.Keyboard, "BlackWidow V3 TKL", LedMappings.Keyboard, RazerEndpointType.Keyboard },
         { 0x02BA, RGBDeviceType.Keyboard, "BlackWidow V4 Mini HyperSpeed", LedMappings.Keyboard, RazerEndpointType.Keyboard },


### PR DESCRIPTION
Hi,

This adds compatibility for the Razer Huntsman V3 Pro (non TKL version) keyboard.

Here’s the overview of the Windows Device Manager for reference:
![Windows Device Manager](https://github.com/user-attachments/assets/a3d4999e-f809-451d-a478-fd94e2f60c09)
