### PR TITLE
Add RGB.NET.Sandbox project

### DIFF
--- a/RGB.NET.Sandbox/Program.cs
+++ b/RGB.NET.Sandbox/Program.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics;
+using RGB.NET.Core;
+using RGB.NET.Presets.Decorators;
+using RGB.NET.Presets.Textures;
+using RGB.NET.Presets.Textures.Gradients;
+
+namespace RGB.NET.Sandbox;
+
+internal class Program
+{
+    public static void Main(string[] args)
+    {
+        long before = Stopwatch.GetTimestamp();
+
+        AbstractRGBDeviceProvider[] deviceProviders = [
+            Devices.Wooting.WootingDeviceProvider.Instance,
+            //Add more device providers here
+        ];
+
+        RGBSurface surface = new();
+        TimerUpdateTrigger timer = new() { UpdateFrequency = 1d / 60 };
+
+        surface.RegisterUpdateTrigger(timer);
+
+        surface.Exception += a => { Console.WriteLine(a.Exception.Message); };
+
+        foreach (AbstractRGBDeviceProvider dp in deviceProviders)
+        {
+            dp.Exception += (a, b) => { Console.WriteLine(b.Exception.Message); };
+            dp.Initialize();
+            foreach (IRGBDevice device in dp.Devices)
+            {
+                Console.WriteLine(device.DeviceInfo.DeviceName);
+            }
+
+            surface.Attach(dp.Devices);
+        }
+
+        TimeSpan after = Stopwatch.GetElapsedTime(before);
+        Console.WriteLine($"Initialized in {after.TotalMilliseconds} ms");
+
+        ILedGroup group = new ListLedGroup(surface, surface.Leds);
+        IGradient gradient = new RainbowGradient();
+        gradient.AddDecorator(new MoveGradientDecorator(surface, 500));
+        group.Brush = new TextureBrush(new LinearGradientTexture(new Size(1, 1), gradient));
+
+        Console.ReadLine();
+
+        foreach (AbstractRGBDeviceProvider dp in deviceProviders)
+        {
+            dp.Dispose();
+        }
+
+        surface.Dispose();
+    }
+}

--- a/RGB.NET.Sandbox/RGB.NET.Sandbox.csproj
+++ b/RGB.NET.Sandbox/RGB.NET.Sandbox.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RGB.NET.Core\RGB.NET.Core.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Asus\RGB.NET.Devices.Asus.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.CoolerMaster\RGB.NET.Devices.CoolerMaster.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Corsair\RGB.NET.Devices.Corsair.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Corsair_Legacy\RGB.NET.Devices.Corsair_Legacy.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Debug\RGB.NET.Devices.Debug.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.DMX\RGB.NET.Devices.DMX.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Logitech\RGB.NET.Devices.Logitech.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Msi\RGB.NET.Devices.Msi.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Novation\RGB.NET.Devices.Novation.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.OpenRGB\RGB.NET.Devices.OpenRGB.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.PicoPi\RGB.NET.Devices.PicoPi.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Razer\RGB.NET.Devices.Razer.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.SteelSeries\RGB.NET.Devices.SteelSeries.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.WLED\RGB.NET.Devices.WLED.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.Wooting\RGB.NET.Devices.Wooting.csproj" />
+    <ProjectReference Include="..\RGB.NET.Devices.WS281X\RGB.NET.Devices.WS281X.csproj" />
+    <ProjectReference Include="..\RGB.NET.Presets\RGB.NET.Presets.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="x64\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/RGB.NET.sln
+++ b/RGB.NET.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32407.343
@@ -50,6 +50,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RGB.NET.Devices.Corsair_Legacy", "RGB.NET.Devices.Corsair_Legacy\RGB.NET.Devices.Corsair_Legacy.csproj", "{66AF690C-27A1-4097-AC53-57C0ED89E286}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RGB.NET.Devices.WLED", "RGB.NET.Devices.WLED\RGB.NET.Devices.WLED.csproj", "{C533C5EA-66A8-4826-A814-80791E7593ED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RGB.NET.Sandbox", "RGB.NET.Sandbox\RGB.NET.Sandbox.csproj", "{BA099D3B-1B54-43D7-BCBE-18182CA91F28}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -145,6 +147,10 @@ Global
 		{C533C5EA-66A8-4826-A814-80791E7593ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C533C5EA-66A8-4826-A814-80791E7593ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C533C5EA-66A8-4826-A814-80791E7593ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA099D3B-1B54-43D7-BCBE-18182CA91F28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA099D3B-1B54-43D7-BCBE-18182CA91F28}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA099D3B-1B54-43D7-BCBE-18182CA91F28}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA099D3B-1B54-43D7-BCBE-18182CA91F28}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adding this simple helper app mostly to ease development of new device providers.

At Wooting, whenever I need to work on RGB SDK related projects, I always reach for RGB.NET and Artemis, but this flow is a bit annoying:
* make changes to device provider
* copy the dll over to artemis
* run artemis
* repeat


So what I usually do is cherry pick this commit with the sandbox app that I've had for ages and work on it first. It's been working great for me and it would be helpful if you don't mind keeping it around in the main repository.

If it's not of interest to you, I can keep the cherry pick approach going, but thought I'd add this as it also serves as an example of how RGB.NET works.

As a sidenote: is `Sandbox` a good name? I can change it to something else if that helps.