### PR TITLE
Add more Logitech devices

### DIFF
--- a/RGB.NET.Devices.Logitech/HID/LightspeedHidLoader.cs
+++ b/RGB.NET.Devices.Logitech/HID/LightspeedHidLoader.cs
@@ -29,7 +29,8 @@ public sealed class LightspeedHIDLoader<TLed, TData> : IEnumerable<HIDDeviceDefi
         0xC53A,
         0xC541,
         0xC545,
-        0xC547
+        0xC547,
+        0xC54D
     ];
 
     #endregion

--- a/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
+++ b/RGB.NET.Devices.Logitech/LogitechDeviceProvider.cs
@@ -75,6 +75,7 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
         { 0xC547, RGBDeviceType.Keyboard, "G915 X TKL", LedMappings.PerKey, 0 },
         { 0xC358, RGBDeviceType.Keyboard, "G515", LedMappings.PerKey, 0 },
         { 0xC363, RGBDeviceType.Keyboard, "G515 Rapid TKL", LedMappings.PerKey, 0 },
+        { 0xC35B, RGBDeviceType.Keyboard, "G Pro X TKL Rapid", LedMappings.PerKey, 0 },
 
         //non-rgb
         { 0xC333, RGBDeviceType.Keyboard, "G610", LedMappings.PerKey, 0 },
@@ -99,6 +100,7 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
         { 0xC336, RGBDeviceType.Keyboard, "G213", LedMappings.ZoneKeyboard, (LogitechDeviceType.Keyboard, 5, 0) },
 
         { 0xC092, RGBDeviceType.Mouse, "G203 Lightsync", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 1, 0) },
+        { 0xC09D, RGBDeviceType.Mouse, "G102 Lightsync", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 1, 0) },
         { 0xC080, RGBDeviceType.Mouse, "G303", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
         { 0xC081, RGBDeviceType.Mouse, "G900", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
         { 0xC082, RGBDeviceType.Mouse, "G403", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
@@ -111,6 +113,7 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
         { 0xC08B, RGBDeviceType.Mouse, "G502 HERO", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
         { 0xC08C, RGBDeviceType.Mouse, "G Pro Hero", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 1, 1) },
         { 0xC08D, RGBDeviceType.Mouse, "G502 Lightspeed", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
+        { 0xC095, RGBDeviceType.Mouse, "G502 X Plus", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
         { 0xC08F, RGBDeviceType.Mouse, "G403 HERO", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
         { 0xC090, RGBDeviceType.Mouse, "G703 Lightspeed", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
         { 0xC091, RGBDeviceType.Mouse, "G903 Lightspeed", LedMappings.ZoneMouse, (LogitechDeviceType.Mouse, 2, 0) },
@@ -161,13 +164,18 @@ public class LogitechDeviceProvider : AbstractRGBDeviceProvider
         { 0xC222, RGBDeviceType.Keyboard, "G15", LedMappings.Device, 0 },
         { 0xC225, RGBDeviceType.Keyboard, "G11", LedMappings.Device, 0 },
         { 0x0AB5, RGBDeviceType.Headset, "G733", LedMappings.Device, 0 },
+        { 0x0AFE, RGBDeviceType.Headset, "G733", LedMappings.Device, 0 },
+        { 0x0B1F, RGBDeviceType.Headset, "G733", LedMappings.Device, 0 },
         { 0xC53A, RGBDeviceType.Mousepad, "POWERPLAY", LedMappings.Device, 0 },
     };
 
     /// <summary>
     /// Gets the HID-definitions for wireless per-device-devices.
     /// </summary>
-    public static LightspeedHIDLoader<int, int> PerDeviceWirelessDeviceDefinitions { get; } = [];
+    public static LightspeedHIDLoader<int, int> PerDeviceWirelessDeviceDefinitions { get; } = new()
+    {
+        { 0x405F, RGBDeviceType.Mousepad, "POWERPLAY", LedMappings.Device, 0 },
+    };
 
     #endregion
 


### PR DESCRIPTION
Adds several missing Logitech device PIDs across keyboards, mice, headsets, and the Powerplay mat. PIDs were cross-referenced against community udev rules and DeviceHunt; only devices with confirmed RGB capability are included.

## Additions

### Keyboards (PerKey)
- 0xC35B - G Pro X TKL Rapid (Hall Effect / magnetic-analog, RGB)

### Mice (PerZone)
- 0xC09D - G102 Lightsync (mirrors G203 Lightsync at 0xC092, single-zone RGB)
- 0xC095 - G502 X Plus (wired, 8-LED RGB)

### Headsets (PerDevice)
- 0x0AFE - G733 (additional firmware revision)
- 0x0B1F - G733 (additional firmware revision)

### Mousepads (PerDevice wireless / Lightspeed)
- 0x405F - POWERPLAY (Lightspeed-virtual PID detected through 0xC53A receiver)

### Lightspeed receivers
- 0xC54D - added to LightspeedHidLoader RECEIVER_PIDS (G Pro X TKL Rapid's Lightspeed-protocol HID++ interface)

## Notes
- G502 X Plus is configured with 2 zones to match other G502 entries; SDK may expose more LEDs, can be tuned after device testing.
- G Pro X TKL Rapid PID (0xC35B) confirmed via a community member's Device Manager output; the other two interfaces (0xC232 generic HID++, 0xC54D Lightspeed) are auxiliary.